### PR TITLE
feat!: changelog writing is now unified under single -o option

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,5 +2,5 @@
 
 set -e
 
-cargo clippy --release -- -D warnings
 cargo fmt -- -v
+cargo clippy --release -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,7 @@ jobs:
         with:
           generate_release_notes: false
           fail_on_unmatched_files: false
-          body:
-            Please refer to
+          body: Please refer to
             [CHANGELOG.md](https://github.com/ydcjeff/chlog/blob/main/CHANGELOG.md)
             for details.
           files: |

--- a/README.md
+++ b/README.md
@@ -56,19 +56,19 @@ chlog -o CHANGELOG.md -r 0 -t v0.1.0
 For the subsequent release,
 
 ```sh
-chlog -p CHANGELOG.md -t v0.2.0
+chlog -o CHANGELOG.md -t v0.2.0
 ```
 
 For the packages with monorepo, you can use `commit-path` option. It will
 generate the changelog scoped to that package.
 
 ```sh
-chlog -p CHANGELOG.md -t v0.3.0 -r 2 --commit-path crates/scope-pkg
+chlog -o CHANGELOG.md -t v0.3.0 -r 2 --commit-path crates/scope-crate
 ```
 
 CLI:
 
-```
+```console
   chlog
 
   Description:
@@ -80,17 +80,18 @@ CLI:
 
   Example:
     $ chlog -o CHANGELOG.md -t v1.0.0
-    $ chlog -p CHANGELOG.md -t v1.0.0
-    $ chlog -p CHANGELOG.md -t v1.0.0 -r 2
-    $ chlog -p CHANGELOG.md -t v1.0.0 -r 2 --commit-path crates/scope-pkg
+    $ chlog -o CHANGELOG.md -t v1.0.0
+    $ chlog -o CHANGELOG.md -t v1.0.0 -r 2
+    $ chlog -o CHANGELOG.md -t v1.0.0 -r 2 --commit-path crates/scope-crate
 
   Options:
     -t  <string>          Tag name for the next release
     -r  <number>          Number of releases to generate the changelog
                           If 0, the whole changelog will be generated
-                          (i.e. first release)
+                          (i.e. first release) (default: 1)
     -o  <file>            File to write the generated changelog
-    -p  <file>            File to prepend the generated changelog
+                          It will prepend the changelogs if the file exists
+                          otherwise, will create a new one
     --commit-path <path>  Generate a changelog scoped to a specific directory
 
   Flags:

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -2,8 +2,8 @@
 
 use std::fs;
 use std::io;
-use std::process;
 use std::path::Path;
+use std::process;
 
 use crate::git;
 use crate::utils;

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -3,12 +3,13 @@
 use std::fs;
 use std::io;
 use std::process;
+use std::path::Path;
 
 use crate::git;
 use crate::utils;
 
-pub fn generate(args: (&str, &str, &str, &str, &str)) {
-  let (prepend, output, count, commit_path, tag) = args;
+pub fn generate(args: (&str, &str, &str, &str)) {
+  let (output, count, commit_path, tag) = args;
 
   let url = git::get_remote_url();
   let mut releases = String::new();
@@ -49,7 +50,7 @@ pub fn generate(args: (&str, &str, &str, &str, &str)) {
     }
   }
 
-  match write(prepend, output, &releases) {
+  match write(output, &releases) {
     Ok(_) => (),
     Err(e) => {
       eprintln!("{}", e);
@@ -129,21 +130,23 @@ fn stringify_commits(commits: Vec<String>, url: &str) -> String {
   commits_list
 }
 
-fn write(prepend: &str, output: &str, to_write: &str) -> io::Result<()> {
+fn write(output: &str, to_write: &str) -> io::Result<()> {
   let placeholder = "<!-- CHLOG_SPLIT_MARKER -->\n";
   let path;
   let contents: String;
 
   if !output.is_empty() {
-    path = output;
-    contents = placeholder.to_owned() + to_write;
-    println!("Generating changelog to {:?}...", path);
-  } else if !prepend.is_empty() {
-    path = prepend;
-    let content = fs::read_to_string(prepend)?;
-    let content: Vec<&str> = content.splitn(2, placeholder).collect();
-    contents = content[0].to_owned() + placeholder + to_write + content[1];
-    println!("Generating changelog and prepending to {:?}...", path);
+    if Path::new(output).exists() {
+      path = output;
+      let content = fs::read_to_string(output)?;
+      let content: Vec<&str> = content.splitn(2, placeholder).collect();
+      contents = content[0].to_owned() + placeholder + to_write + content[1];
+      println!("Generating changelog and prepending to {:?}...", path);
+    } else {
+      path = output;
+      contents = placeholder.to_owned() + to_write;
+      println!("Generating changelog to {:?}...", path);
+    }
   } else {
     println!("{}", to_write);
     return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,17 +36,18 @@ fn show_help() {
 
   Example:
     $ chlog -o CHANGELOG.md -t v1.0.0
-    $ chlog -p CHANGELOG.md -t v1.0.0
-    $ chlog -p CHANGELOG.md -t v1.0.0 -r 2
-    $ chlog -p CHANGELOG.md -t v1.0.0 -r 2 --commit-path crates/scope-pkg
+    $ chlog -o CHANGELOG.md -t v1.0.0
+    $ chlog -o CHANGELOG.md -t v1.0.0 -r 2
+    $ chlog -o CHANGELOG.md -t v1.0.0 -r 2 --commit-path crates/scope-crate
 
   Options:
     -t  <string>          Tag name for the next release
     -r  <number>          Number of releases to generate the changelog
                           If 0, the whole changelog will be generated
-                          (i.e. first release)
+                          (i.e. first release) (default: 1)
     -o  <file>            File to write the generated changelog
-    -p  <file>            File to prepend the generated changelog
+                          It will prepend the changelogs if the file exists
+                          otherwise, will create a new one
     --commit-path <path>  Generate a changelog scoped to a specific directory
 
   Flags:

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -178,10 +178,21 @@ List items
     let args = ["-o", "output.md", "-r", "2"].map(String::from);
     assert_eq!(parse_args(&args), ("output.md", "2", ".", ""));
 
-    let args = [ "-o", "output.md", "-r", "2", "--commit-path", "test"].map(String::from);
+    let args =
+      ["-o", "output.md", "-r", "2", "--commit-path", "test"].map(String::from);
     assert_eq!(parse_args(&args), ("output.md", "2", "test", ""));
 
-    let args = ["-o","output.md","-r","2","--commit-path","test","-t","v1.0.0"].map(String::from);
+    let args = [
+      "-o",
+      "output.md",
+      "-r",
+      "2",
+      "--commit-path",
+      "test",
+      "-t",
+      "v1.0.0",
+    ]
+    .map(String::from);
     assert_eq!(parse_args(&args), ("output.md", "2", "test", "v1.0.0"));
   }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -47,8 +47,7 @@ pub fn process_commit(commit: &str) -> (&str, &str, &str, &str, &str) {
   )
 }
 
-pub fn parse_args(args: &[String]) -> (&str, &str, &str, &str, &str) {
-  let mut prepend = "";
+pub fn parse_args(args: &[String]) -> (&str, &str, &str, &str) {
   let mut output = "";
   let mut count = "1";
   let mut commit_path = ".";
@@ -60,9 +59,6 @@ pub fn parse_args(args: &[String]) -> (&str, &str, &str, &str, &str) {
     let next = args.next();
     match next {
       Some(v) => match v.as_str() {
-        "-p" => {
-          prepend = args.next().unwrap();
-        }
         "-o" => {
           output = args.next().unwrap();
         }
@@ -84,7 +80,7 @@ pub fn parse_args(args: &[String]) -> (&str, &str, &str, &str, &str) {
     }
   }
 
-  (prepend, output, count, commit_path, tag)
+  (output, count, commit_path, tag)
 }
 
 #[cfg(test)]
@@ -176,45 +172,16 @@ List items
 
   #[test]
   fn test_parse_args() {
-    let args = ["-p", "prepend.md", "-o", "output.md"].map(String::from);
-    assert_eq!(parse_args(&args), ("prepend.md", "output.md", "1", ".", ""));
+    let args = ["-o", "output.md"].map(String::from);
+    assert_eq!(parse_args(&args), ("output.md", "1", ".", ""));
 
-    let args =
-      ["-p", "prepend.md", "-o", "output.md", "-r", "2"].map(String::from);
-    assert_eq!(parse_args(&args), ("prepend.md", "output.md", "2", ".", ""));
+    let args = ["-o", "output.md", "-r", "2"].map(String::from);
+    assert_eq!(parse_args(&args), ("output.md", "2", ".", ""));
 
-    let args = [
-      "-p",
-      "prepend.md",
-      "-o",
-      "output.md",
-      "-r",
-      "2",
-      "--commit-path",
-      "test",
-    ]
-    .map(String::from);
-    assert_eq!(
-      parse_args(&args),
-      ("prepend.md", "output.md", "2", "test", "")
-    );
+    let args = [ "-o", "output.md", "-r", "2", "--commit-path", "test"].map(String::from);
+    assert_eq!(parse_args(&args), ("output.md", "2", "test", ""));
 
-    let args = [
-      "-p",
-      "prepend.md",
-      "-o",
-      "output.md",
-      "-r",
-      "2",
-      "--commit-path",
-      "test",
-      "-t",
-      "v1.0.0",
-    ]
-    .map(String::from);
-    assert_eq!(
-      parse_args(&args),
-      ("prepend.md", "output.md", "2", "test", "v1.0.0")
-    );
+    let args = ["-o","output.md","-r","2","--commit-path","test","-t","v1.0.0"].map(String::from);
+    assert_eq!(parse_args(&args), ("output.md", "2", "test", "v1.0.0"));
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`-p` is now removed. Instead use `-o` as usual. It will create
the output file if the file does not exist and write the changelog
to it. If the file exists, the generated changelog will be
prepended to the file.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other
